### PR TITLE
Restructure split buttons

### DIFF
--- a/packages/blocks/src/components/SplitButton/SplitButton.tsx
+++ b/packages/blocks/src/components/SplitButton/SplitButton.tsx
@@ -1,13 +1,14 @@
 import React from 'react';
 import cx from 'classnames';
 import { CaretDownIcon } from '@mergestat/icons';
+import { Button } from '../Button';
 import { Dropdown } from '../Dropdown';
 import { Menu } from '../Menu';
 
 export type SplitButtonItemProps = {
   text?: string;
   icon?: React.ReactElement;
-  className?: string; 
+  className?: string;
 }
 
 export type SplitButtonProps = {
@@ -34,26 +35,18 @@ export const SplitButton: React.FC<SplitButtonProps> = React.forwardRef(({
   menuContainerClassName,
 }, ref: any) => {
   return (
-    <div className={cx("t-flex-split", {[className]: !!className})} ref={ref}>
-      <label
-        onClick={() => {
-          if (!disabled && onButtonClick) onButtonClick();
-        }}
-        className="t-split-gray h-full"
+    <div className={cx("t-split-button", {[className]: !!className})} ref={ref}>
+      <div
       >
-        {startIcon && startIcon}
-        <button disabled={disabled}>
-          {text || "Split Button"}
-        </button>
-        {endIcon && endIcon}
-      </label>
+        <Button skin="secondary" startIcon={startIcon} endIcon={endIcon} disabled={disabled} label={text || "Split button"} className="t-split-button-left" onClick={() => {
+          if (!disabled && onButtonClick) onButtonClick();
+        }} />
+      </div>
       <Dropdown
         alignEnd
         disabled={disabled}
         trigger={
-          <div className="relative t-split-gray h-full cursor-pointer border-l">
-            <CaretDownIcon className="t-icon" />
-          </div>
+          <Button skin="secondary" isIconOnly startIcon={<CaretDownIcon className="t-icon" />} className="t-split-button-right" />
         }
         overlay={(close: any) => (
           <Menu className={cx('absolute right-0 -top-1.5', { [menuContainerClassName]: !!menuContainerClassName})}>

--- a/packages/blocks/src/components/SplitButton/SplitButton.tsx
+++ b/packages/blocks/src/components/SplitButton/SplitButton.tsx
@@ -38,9 +38,16 @@ export const SplitButton: React.FC<SplitButtonProps> = React.forwardRef(({
     <div className={cx("t-split-button", {[className]: !!className})} ref={ref}>
       <div
       >
-        <Button skin="secondary" startIcon={startIcon} endIcon={endIcon} disabled={disabled} label={text || "Split button"} className="t-split-button-left" onClick={() => {
-          if (!disabled && onButtonClick) onButtonClick();
-        }} />
+        <Button
+          skin="secondary"
+          startIcon={startIcon}
+          endIcon={endIcon}
+          disabled={disabled} label={text || "Split button"}
+          className="t-split-button-left"
+          onClick={() => {
+            if (!disabled && onButtonClick) onButtonClick();
+          }}
+        />
       </div>
       <Dropdown
         alignEnd

--- a/packages/blocks/src/components/SplitButton/SplitButton.tsx
+++ b/packages/blocks/src/components/SplitButton/SplitButton.tsx
@@ -53,7 +53,12 @@ export const SplitButton: React.FC<SplitButtonProps> = React.forwardRef(({
         alignEnd
         disabled={disabled}
         trigger={
-          <Button skin="secondary" isIconOnly startIcon={<CaretDownIcon className="t-icon" />} className="t-split-button-right" />
+          <Button
+            skin="secondary"
+            isIconOnly
+            startIcon={<CaretDownIcon className="t-icon" />}
+            className="t-split-button-right"
+          />
         }
         overlay={(close: any) => (
           <Menu className={cx('absolute right-0 -top-1.5', { [menuContainerClassName]: !!menuContainerClassName})}>

--- a/packages/blocks/styles/components/t-split-button.css
+++ b/packages/blocks/styles/components/t-split-button.css
@@ -1,45 +1,13 @@
-.t-flex-split {
-  height: fit-content;
-  width: fit-content;
-  display: flex;
-  font-size: 14px;
-  align-items: center;
-  overflow: hidden;
-  border:1px solid rgba(186, 230, 253);
-  @apply rounded
-       border-gray-300
-         focus_outline-none
-         focus_ring-offset-2
-         focus_ring-blue-500
-         font-medium;
+.t-split-button {
+  @apply flex
+         items-center
+         -space-x-0.5;
 }
 
-.t-flex-split img {
-  padding: 2px;
-  margin-right: 3px;
+.t-split-button-left {
+  @apply rounded-r-none;
 }
 
-.t-split-gray {
-  display: flex;
-  height: 34px !important;
-  align-items: center;
-  justify-content: center;
-  font-weight: 600;
-  @apply bg-gradient-to-b
-      border-gray-300
-      text-gray-700
-      pl-2 
-      pr-2
-      leading-5
-      from-white 
-      to-gray-100 
-      hover_from-gray-50 
-      hover_to-gray-150 
-      active_shadow-inner;
-}
-
-.t-flex-split .t-divider {
-  height: 34px !important;
-  border-left: 1px solid rgba(209, 213, 219);
-  /* @apply ml-3 mr-2; */
+.t-split-button-right {
+  @apply rounded-l-none;
 }


### PR DESCRIPTION
I have restructured the split buttons a bit so that they automatically inherit the `t-button` styling and are in line with the structure of split buttons in [bootstrap](https://getbootstrap.com/docs/5.0/components/dropdowns/#split-button) for example:

I've tried to keep the functionality intact (hopefully), no worries if the restructuring would be too much, then you can just ignore this and I can take a look then to modify the styling only instead 