### PR TITLE
Re add focus styles

### DIFF
--- a/packages/blocks/styles/components/t-button.css
+++ b/packages/blocks/styles/components/t-button.css
@@ -11,7 +11,7 @@
          px-3
          leading-5
          focus_outline-none
-         /* focus_ring-2 */
+         focus_ring-2
          focus_ring-offset-2
          focus_ring-blue-500
          font-medium


### PR DESCRIPTION
I noticed there are no visual changes when a button receives focus, I'd definitely recommend adding this again to ensure keyboard accessibility (or alternatively keep the default browser focus outline).

(Let me know if I should visually review the focus styles if they would not be ok)

