### PR TITLE
Release with building

### DIFF
--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -16,6 +16,27 @@ import css assets into top level of component project.
 import '@mergestat/blocks/styles/main.css'
 ```
 
+## How to Publish to NPM
+
+Go to `package.json` and upgrade the version manually.
+
+```
+{
+  "name": "@mergestat/blocks",
+  "version": "1.2.6",  <----------- <Upgrade here>
+}
+```
+
+Then `login`, `build` and `publish`
+
+```
+npm login
+```
+
+```
+npm run release
+```
+
 ## How to use the Blocks
 
 If you want to use components from the Blocks, check the [Storybook documentation](https://624b441a141307004a094f09-iskoqummxn.chromatic.com/)

--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mergestat/blocks",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "description": "Set of UI components for MergeStat project",
   "repository": {
     "type": "git",


### PR DESCRIPTION
I forgot to build and then publish. In previous version was published a version with empty module. My bad.

In this PR I upgrade the version and add a description to `READEME` to run `npm run release`.