### PR TITLE
fix: adjustment to cursor behavior on selected radio card

### DIFF
--- a/packages/blocks/styles/components/t-radio-card.css
+++ b/packages/blocks/styles/components/t-radio-card.css
@@ -20,7 +20,6 @@
 }
 
 .t-radio-card.t-tag-blue {
-  cursor:default;
   @apply bg-blue-100
          text-blue-600
          ring-1


### PR DESCRIPTION
IMO `cursor: pointer` should always be set on the radio card item, even if it's already selected, to indicate that it was clickable