### PR TITLE
feat: implement a "dynamic" icon in `Alert` component

### DIFF
--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mergestat/blocks",
-  "version": "1.2.8",
+  "version": "1.3.0",
   "description": "Set of UI components for MergeStat project",
   "repository": {
     "type": "git",

--- a/packages/blocks/src/components/Alert/Alert.stories.tsx
+++ b/packages/blocks/src/components/Alert/Alert.stories.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
 
 import { Alert } from './Alert';
+import { Spinner } from '../Loader/Spinner/Spinner';
 
 export default {
   title: 'Molecules/Alert',
@@ -131,4 +132,19 @@ InlineAlertError.args = {
   type: 'error',
   isInline: true,
   children: 'This is an inline alert message',
+}
+
+export const InfoAlertSpinner = Template.bind({});
+InfoAlertSpinner.args = {
+  type: 'info',
+  icon: <Spinner size='sm' className="t-icon self-center" />,
+  title: 'This is an alert with a spinner'
+}
+
+export const InfoAlertSpinnerContent = Template.bind({});
+InfoAlertSpinnerContent.args = {
+  type: 'info',
+  icon: <Spinner size='sm' className="t-icon" />,
+  title: 'This is an alert with a spinner',
+  children: 'This is the alert content'
 }

--- a/packages/blocks/src/components/Alert/Alert.tsx
+++ b/packages/blocks/src/components/Alert/Alert.tsx
@@ -13,6 +13,7 @@ type AlertProps = {
   isInline?: boolean;
   title?: string | React.ReactNode;
   noIcon?: boolean;
+  icon?: React.ReactNode;
   children?: React.ReactNode;
 }
 
@@ -25,6 +26,7 @@ export const Alert: React.FC<AlertProps> = ({
   className,
   isInline = false,
   noIcon = false,
+  icon = null,
   children
 }) => {
   const [visible, setVisible] = useState<boolean>(true);
@@ -46,7 +48,8 @@ export const Alert: React.FC<AlertProps> = ({
         }
       )}
     >
-      {!noIcon && <AlertIcon type={type} />}
+      {!noIcon && !icon && <AlertIcon type={type} />}
+      {icon && icon}
       {isInline ? (
         children && (
           <p className={cx("t-inline-alert-message", {'ml-2': !noIcon})}>


### PR DESCRIPTION
adds the `icon` prop (which should be "backwards compatible") to allow the user to set any ReactNode as the "icon" in an alert.

Enables something like:

<img width="1138" alt="image" src="https://user-images.githubusercontent.com/57259/193966924-fd9021ec-e594-4e2b-9185-fb9a91a83908.png">

Closes #77 
