### PR TITLE
feat: update table styles

### DIFF
--- a/packages/blocks/src/components/Table/Table.stories.tsx
+++ b/packages/blocks/src/components/Table/Table.stories.tsx
@@ -133,3 +133,17 @@ ClickableTable.args = {
   renderCollapse: (d: any) => d.description,
   clickable: true
 }
+
+export const BorderedTable = Template.bind({});
+BorderedTable.args = {
+  columns: columns,
+  dataSource: dataSource,
+  bordered: true,
+}
+
+export const DenseTable = Template.bind({});
+DenseTable.args = {
+  columns: columns,
+  dataSource: dataSource,
+  dense: true,
+}

--- a/packages/blocks/src/components/Table/Table.tsx
+++ b/packages/blocks/src/components/Table/Table.tsx
@@ -34,6 +34,8 @@ type TableProps = {
   onSelectedChange?: (selectedRows: Array<any>) => void;
   collapsible?: boolean;
   clickable?: boolean;
+  dense?:boolean,
+  bordered?:boolean,
   renderCollapse?: (data: any) => void
 };
 
@@ -57,6 +59,8 @@ export const Table: React.FC<TableProps> = ({
   selectAll = false,
   collapsible = false,
   clickable = false,
+  dense = false,
+  bordered = false,
   renderCollapse = () => {},
 }) => {
   if (loading) {
@@ -178,6 +182,8 @@ export const Table: React.FC<TableProps> = ({
           [`t-table-hover`]: hovered,
           [`t-table-sticky-header`]: !!scrollY,
           [`t-table-clickable`]: clickable,
+          [`t-table-dense`]: dense,
+          [`t-table-bordered`]: bordered,
           [className]: !!className,
         })}
       >

--- a/packages/blocks/styles/components/t-table.css
+++ b/packages/blocks/styles/components/t-table.css
@@ -11,14 +11,22 @@
 
 /* Table with sticky header */
 .t-table-sticky-header {
-  border-spacing: 0;
-  @apply border-separate;
+  border-collapse: collapse;
 }
 
 .t-table-sticky-header thead tr {
   @apply sticky
          z-10
          top-0;
+}
+
+.t-table-sticky-header thead tr th:before {
+  content: '';
+  @apply absolute
+         left-0
+         w-full
+         -bottom-px
+         border-b-2;
 }
 
 /* When a table heading occurs in the tbody part */
@@ -70,6 +78,11 @@
   @apply border-0;
 }
 
+.t-table-hover tbody .t-table-row-muted:hover,
+.t-table-hover tbody .t-table-row-muted:focus-within {
+  @apply bg-gray-100;
+}
+
 /* custom class rc table */
 .t-table-content table {
   @apply w-full;
@@ -89,19 +102,22 @@
   white-space: nowrap;
 }
 
+/* Table with hover effect on rows */
+.t-table-hover tbody tr:hover,
+.t-table-hover tbody tr:focus-within {
+  @apply bg-gray-50;
+}
+
 /* Table with hover actions */
-.t-table-hover .t-button-toolbar {
+.t-table-hover-actions .t-button-toolbar {
   @apply hidden;
 }
 
-.t-table-hover tbody tr {
+.t-table-hover-actions tbody tr {
   @apply relative;
 }
 
-.t-table-hover tbody tr:hover {
-  @apply bg-gray-50;
-}
-.t-table-hover tbody tr:hover .t-button-toolbar {
+.t-table-hover-actions tbody tr:hover .t-button-toolbar {
   @apply block
          top-1/2
          transform
@@ -116,14 +132,17 @@
            cursor-pointer;
 }
 
+/* Table col visible for screen readers only */
 .t-sr-accessible-table-col {
   position: absolute !important;
-  height: 1px; width: 1px;
+  height: 1px;
+  width: 1px;
   overflow: hidden;
   clip: rect(1px 1px 1px 1px); /* IE6, IE7 */
   clip: rect(1px, 1px, 1px, 1px);
 }
 
+/* Sortable tables */
 .sortable__th__arrow-wrapper {
   display: inline-block;
   cursor: pointer;
@@ -163,3 +182,71 @@ table th.down .sortable__th__arrow {
   border-top-color: #00a8ea;
 }
 
+/* Last rows should not show a border */
+.t-table tr:last-child .t-table-cell,
+.t-table-default tr:last-child td {
+  @apply border-0;
+}
+
+/* Table spacing */
+.t-table-default td,
+.t-table-default th {
+  @apply px-6;
+}
+
+.t-table-default td:first-child,
+.t-table-default th:first-child {
+  @apply pl-8;
+}
+
+.t-table-default td:last-child,
+.t-table-default th:last-child {
+  @apply pr-8;
+}
+
+/* Bordered tables */
+.t-table-bordered td,
+.t-table-bordered th {
+  @apply border
+         border-gray-250;
+}
+
+.t-table-bordered th {
+  @apply border-t-0
+         border-b-2;
+}
+
+.t-table-bordered tr:last-child td {
+  @apply border-0
+          border-r
+          border-l;
+}
+
+.t-table-bordered td:first-child,
+.t-table-bordered th:first-child,
+.t-table-bordered tr:last-child td:first-child {
+  @apply border-l-0;
+}
+
+.t-table-bordered td:last-child,
+.t-table-bordered th:last-child,
+.t-table-bordered tr:last-child td:last-child {
+  @apply border-r-0;
+}
+
+/* Dense tables */
+.t-table-dense td {
+  @apply py-2.5
+         text-sm;
+}
+
+.t-table-dense th {
+  @apply pt-3.5
+         pb-2
+         text-sm;
+}
+
+/* Muted table row */
+.t-table-row-muted {
+  @apply bg-gray-50;
+}

--- a/packages/blocks/tailwind.config.js
+++ b/packages/blocks/tailwind.config.js
@@ -14,7 +14,9 @@ module.exports = {
     extend: {
       colors: {
         gray: {
-          150: "#EBECEF",
+          150: '#EBECEF',
+          250: '#DDDFE4',
+          350: 'B9C0CB',
           450: '#727C8D'
         },
       },


### PR DESCRIPTION
Syncs new styles from the `mergestat` repo back into `blocks`:

- Added bordered variant
- Added dense variant
- Tweaked sticky header styling approach so it also works for the bordered variant
- Added default cell padding 
- Updated `t-table-hover` styles and separated specific styles for table rows with hover actions to `t-table-hover-actions` (these were previously used in the query results table for copy button on hover)


#### 2 new variants:
<img width="1120" alt="image" src="https://user-images.githubusercontent.com/36261498/195818592-ae806983-8551-4203-a424-548871a5bda2.png">
