### PR TITLE
feat: update default logbox text color

### DIFF
--- a/packages/blocks/src/components/LogBox/LogBox.tsx
+++ b/packages/blocks/src/components/LogBox/LogBox.tsx
@@ -12,7 +12,7 @@ type LogBoxProps = {
 
 export const LogBox: React.FC<LogBoxProps> = ({ logs, className, copyBtnClassName, onCopy }) => {
   return (
-    <div className={cx("t-log-box bg-gray-800 text-white rounded-md font-mono text-xs leading-6", { [className]: !!className })}>
+    <div className={cx("t-log-box bg-gray-800 text-gray-200 rounded-md font-mono text-xs leading-6", { [className]: !!className })}>
       {logs.map((log, index) => (
         <p key={index}>
           {log}


### PR DESCRIPTION
Updated default logbox text color from white to a light gray as it's a bit softer to read 
<img width="1033" alt="image" src="https://user-images.githubusercontent.com/36261498/195820794-f3cf0d8e-fef2-4799-af90-29566b5c3507.png">
