### PR TITLE
feat: add input with prepend styles

### DIFF
--- a/packages/blocks/styles/components/t-input.css
+++ b/packages/blocks/styles/components/t-input.css
@@ -39,3 +39,21 @@
 .t-input-error {
     @apply border-red-500;
 }
+
+.t-input-with-prepend {
+  @apply flex
+         items-center;
+}
+
+.t-input-with-prepend *:first-child {
+  @apply z-10;
+}
+
+.t-input-with-prepend .t-button {
+  @apply rounded-r-none;
+}
+
+.t-input-with-prepend .t-input {
+  @apply rounded-l-none
+         -ml-px;
+}


### PR DESCRIPTION
This syncs the styles that were added in `mergestat` to `blocks` for inputs with prepend, like used here:

<img width="843" alt="image" src="https://user-images.githubusercontent.com/36261498/195822504-91431093-b94d-40e8-ad26-bf39ab585144.png">
