### PR TITLE
feat: update alert styles

### DIFF
--- a/packages/blocks/src/components/Alert/Alert.stories.tsx
+++ b/packages/blocks/src/components/Alert/Alert.stories.tsx
@@ -43,6 +43,24 @@ WarningLightTitleOnly.args = {
   title: 'Alert Title'
 }
 
+export const WarningFullWidth = Template.bind({});
+WarningFullWidth.args = {
+  type: 'warning',
+  closeable: false,
+  isFullWidth: true,
+  theme: 'light',
+  children: 'Alert Content',
+}
+
+export const DefaultLight = Template.bind({});
+DefaultLight.args = {
+  type: 'default',
+  closeable: false,
+  theme: 'light',
+  title: 'Alert Title',
+  children: 'Alert Content',
+}
+
 export const InfoLight = Template.bind({});
 InfoLight.args = {
   type: 'info',

--- a/packages/blocks/src/components/Alert/Alert.tsx
+++ b/packages/blocks/src/components/Alert/Alert.tsx
@@ -5,12 +5,13 @@ import { AlertIcon } from './AlertIcon';
 import { Button } from '../Button';
 
 type AlertProps = {
-  type?: 'warning' | 'info' | 'success' | 'error';
+  type?: 'warning' | 'info' | 'success' | 'error' | 'default';
   closable?: boolean;
   onClose?: () => void;
   theme?: 'dark' | 'light';
   className?: string;
   isInline?: boolean;
+  isFullWidth?: boolean;
   title?: string | React.ReactNode;
   noIcon?: boolean;
   icon?: React.ReactNode;
@@ -25,6 +26,7 @@ export const Alert: React.FC<AlertProps> = ({
   title,
   className,
   isInline = false,
+  isFullWidth = false,
   noIcon = false,
   icon = null,
   children
@@ -43,6 +45,7 @@ export const Alert: React.FC<AlertProps> = ({
       className={cx(
         isInline ? 't-inline-alert' : `t-alert t-alert-${type} align-center`,
         {
+          [`t-alert-full-width`]: isFullWidth,
           [`t-alert-${theme}`]: !!theme,
           [className]: !!className,
         }
@@ -57,7 +60,7 @@ export const Alert: React.FC<AlertProps> = ({
           </p>
         )
       ) : (
-        <div className={cx("t-alert-body", {'ml-4': !noIcon})}>
+        <div className={cx("t-alert-body", {'ml-3': !noIcon})}>
           {title && (
             <h3 className="t-alert-title">{title}</h3>
           )}
@@ -68,7 +71,7 @@ export const Alert: React.FC<AlertProps> = ({
           )}
         </div>
       )}
-      
+
       {closable && (
         <Button skin="borderless-muted" onClick={handleOnClose}>
           <XIcon className="t-icon t-icon-heroicons-x" />

--- a/packages/blocks/src/components/Alert/AlertIcon.tsx
+++ b/packages/blocks/src/components/Alert/AlertIcon.tsx
@@ -10,27 +10,27 @@ export const AlertIcon: React.FC<{ type?: string }> = ({ type = 'warning' }) => 
   switch (type) {
     case 'warning':
       return (
-        <WarningFilledIcon className="t-icon t-icon-mono-icons-warning-filled t-icon-warning" />
+        <WarningFilledIcon className="t-icon t-icon-warning" />
       );
 
     case 'info':
       return (
-        <CircleInformationFilledIcon className="t-icon t-icon-mono-icons-circle-information-filled t-icon-info" />
+        <CircleInformationFilledIcon className="t-icon t-icon-info" />
       );
 
     case 'success':
       return (
-        <CircleCheckFilledIcon className="t-icon t-icon-mono-icons-circle-check-filled t-icon-success" />
+        <CircleCheckFilledIcon className="t-icon t-icon-success" />
       );
 
     case 'error':
       return (
-        <CircleWarningFilledIcon className="t-icon t-icon-mono-icons-circle-warning-filled t-icon-danger" />
+        <CircleWarningFilledIcon className="t-icon t-icon-danger" />
       );
 
     default:
       return (
-        <WarningFilledIcon className="t-icon t-icon-mono-icons-warning-filled t-icon-warning" />
+        <CircleInformationFilledIcon className="t-icon t-iconinfo" />
       );
   }
 }

--- a/packages/blocks/styles/components/t-alert.css
+++ b/packages/blocks/styles/components/t-alert.css
@@ -3,7 +3,7 @@
    ========================================================================== */
 
 .t-alert {
-    @apply rounded-md
+  @apply rounded-md
            flex
            items-start
            p-4
@@ -11,12 +11,11 @@
 }
 
 .t-alert .t-icon {
-    @apply my-0.5;
+  @apply my-0.5;
 }
 
-
 .t-alert-title {
-    @apply font-medium;
+  @apply font-medium;
 }
 
 .t-alert-title + .t-alert-message {
@@ -24,7 +23,7 @@
 }
 
 .t-alert-body {
-    @apply flex-1;
+  @apply flex-1;
 }
 
 .t-alert .t-icon svg * {
@@ -32,68 +31,85 @@
 }
 
 /* Skins */
+.t-alert-default {
+  @apply bg-gray-50
+          text-gray-600;
+}
+
+.t-alert-default .t-alert-title {
+  @apply text-gray-900;
+}
+
+.t-alert-default .t-icon:first-child {
+  @apply text-blue-500;
+}
+
 .t-alert-info {
-    @apply bg-blue-50
-           border-blue-300
-           text-blue-700;
+  color: #457287;
+  @apply bg-blue-50
+           border-blue-400
+           border-opacity-50;
 }
 
 .t-alert-info .t-alert-title {
-    @apply text-blue-800;
+  @apply text-blue-900;
 }
 
 .t-alert-info .t-icon:first-child {
-    @apply text-blue-500;
+  @apply text-blue-500;
 }
 
 .t-alert-warning {
-    @apply bg-yellow-50
-           border-yellow-300
-           text-yellow-700;
+  color: #7E6944;
+  @apply bg-yellow-50
+           border-yellow-400
+           border-opacity-50;
 }
 
 .t-alert-warning .t-alert-title {
-    @apply text-yellow-800;
+  @apply text-yellow-900;
 }
 .t-alert-warning .t-icon:first-child {
-    @apply text-yellow-500;
+  @apply text-yellow-500;
 }
 
 .t-alert-error {
-    @apply bg-red-50
-           border-red-300
-           text-red-700;
+  color: #7A5252;
+  @apply bg-red-50
+          border-red-400
+          border-opacity-50;
 }
 
 .t-alert-error .t-alert-title {
-    @apply text-red-800;
+  @apply text-red-900;
 }
 
 .t-alert-error .t-icon:first-child {
-    @apply text-red-500;
+  @apply text-red-500;
 }
 
 .t-alert-success {
-    @apply bg-green-50
-           border-green-300
-           text-green-700;
+  color: #56766C;
+  @apply bg-green-50
+           border-green-400
+           border-opacity-50;
 }
 
 .t-alert-success .t-alert-title {
-    @apply text-green-800;
+  @apply text-green-900;
 }
 .t-alert-success .t-icon:first-child {
-    @apply text-green-500;
+  @apply text-green-500;
 }
 
 .t-alert-dark {
-    @apply bg-gray-800
+  @apply bg-gray-800
            border-gray-800
            text-gray-400;
 }
 
 .t-alert-dark .t-alert-title {
-    @apply text-white;
+  @apply text-white;
 }
 
 .t-inline-alert {
@@ -104,4 +120,14 @@
 .t-inline-alert-message {
   @apply text-sm
          text-gray-500;
+}
+
+.t-alert-full-width {
+  @apply border-0
+         border-b
+         text-sm
+         items-center
+         py-2.5
+         px-8
+         rounded-none;
 }


### PR DESCRIPTION
- Added default neutral variant
- Added full width alert variant
- Updated styles to make the alerts a bit softer
   -  Only added a small hint of color to the message text so it doesn't clash entirely with the background, but it's more readable
   - Added more contrast between titles and message
   

#### Neutral variant
<img width="1074" alt="image" src="https://user-images.githubusercontent.com/36261498/195828467-d56644eb-3ab1-4623-bce3-67da522626e7.png">


#### Full width variant
Can for example be used at the top of views for more general messages:
<img width="1085" alt="image" src="https://user-images.githubusercontent.com/36261498/195828594-4dc88111-40e0-42b0-8660-b15c363c7fce.png">

#### Updated colors:
Previous colors on the left, new ones on the right:
![image](https://user-images.githubusercontent.com/36261498/195828498-7855b923-2cca-48da-bb1c-dd4971fd4e47.png)

(Resolves #59)