### PR TITLE
feat: update table header styles

### DIFF
--- a/packages/blocks/styles/components/t-table.css
+++ b/packages/blocks/styles/components/t-table.css
@@ -62,8 +62,9 @@
   @apply py-3
          text-left
          border-b-2
-         font-medium
-         text-gray-900;
+         font-semibold
+         bg-gray-50
+         text-gray-700;
 }
 
 /* Alignment for button toolbars */
@@ -235,14 +236,9 @@ table th.down .sortable__th__arrow {
 }
 
 /* Dense tables */
+.t-table-dense th,
 .t-table-dense td {
   @apply py-2.5
-         text-sm;
-}
-
-.t-table-dense th {
-  @apply pt-3.5
-         pb-2
          text-sm;
 }
 


### PR DESCRIPTION
Some last styles that were added on `fuse` on the `add-query-editor` branch which adds more contrast to the table header by default:

![image](https://user-images.githubusercontent.com/36261498/196469262-41cb3474-baf4-47ac-b043-0cd489144a54.png)
