### PR TITLE
Add missing styles

### DIFF
--- a/packages/blocks/styles/components/t-modal.css
+++ b/packages/blocks/styles/components/t-modal.css
@@ -49,7 +49,6 @@
           transition-all
           sm_align-middle
           sm_max-w-2xl
-          max-h-full
           w-full;
 }
 

--- a/packages/blocks/styles/components/t-nav.css
+++ b/packages/blocks/styles/components/t-nav.css
@@ -20,8 +20,12 @@
            border-gray-500;
 }
 
-.t-nav-item > a {
+.t-nav-item > a,
+.t-nav-item > button {
     @apply px-5
+           border-0
+           bg-transparent
+           gap-3
            font-medium
            inline-flex
            items-center

--- a/packages/blocks/styles/components/t-resizer.css
+++ b/packages/blocks/styles/components/t-resizer.css
@@ -3,7 +3,9 @@
    ========================================================================== */
 
 .t-resizer {
+  cursor: row-resize;
   @apply bg-gray-50
+           w-full
            mix-blend-multiply
            py-1;
 }


### PR DESCRIPTION
When updating the package (https://github.com/mergestat/mergestat/pull/413) I noticed that some styles were still missing in blocks

- Resizer missed full width & cursor class 
- Nav item didn't have button element styles yet
- Modal max height was overridden by `max-h-full` class in `@apply` list