### PR TITLE
chore(dependencies): Updating pipeline to execute npm i

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Install dependencies
         run: |
           cd packages/blocks
-          npm ci
+          npm i
 
       - name: Publish to Chromatic
         uses: chromaui/action@v1


### PR DESCRIPTION
Updating pipeline to execute `npm i` because `npm ci` is not updating correctly `package-lock.json` file.