### PR TITLE
fix: move dropdown menus closer to trigger

### DIFF
--- a/packages/blocks/src/components/Dropdown/Dropdown.tsx
+++ b/packages/blocks/src/components/Dropdown/Dropdown.tsx
@@ -37,8 +37,7 @@ const DropdownContent: React.FC<
   >
 > = ({ overlay, zIndex }) => {
   const [props, { show }] = useDropdownMenu({
-    flip: true,
-    offset: [0, 8],
+    flip: true
   });
 
   return (

--- a/packages/blocks/styles/components/t-menu.css
+++ b/packages/blocks/styles/components/t-menu.css
@@ -9,6 +9,7 @@
     @apply origin-top-right
            relative
            py-1
+           mt-1
            rounded-md
            shadow-lg
            border

--- a/packages/blocks/styles/components/t-multi-select.css
+++ b/packages/blocks/styles/components/t-multi-select.css
@@ -7,7 +7,6 @@
   @apply absolute
          left-0
          right-0
-         mt-2
          w-full;
 }
 


### PR DESCRIPTION

- Removed offset of 8px on `Dropdown` component
- Added 4px top-margin to `t-menu` in css instead for consistency

<img width="232" alt="image" src="https://user-images.githubusercontent.com/36261498/205286331-fccdd170-b47c-4040-9402-f97939f80191.png">


#124