### PR TITLE
feat: add small breadcrumb variant

### DIFF
--- a/packages/blocks/src/components/BreadcrumbNav/BreadcrumbNav.stories.tsx
+++ b/packages/blocks/src/components/BreadcrumbNav/BreadcrumbNav.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {
-  CircleErrorFilledIcon,
+  CircleCheckFilledIcon,
   ExternalLinkIcon,
   RepositoryIcon
 } from '@mergestat/icons';
@@ -22,12 +22,30 @@ Default.args = {
     { text: "Repos" },
     {
       startIcon: <ColoredBox onClick={() => {}} size="8" skin="default"><RepositoryIcon className="t-icon t-icon-small" /></ColoredBox>,
-      text: "vercel/next.js",
+      text: "mergestat/mergestat",
       endIcon: <ExternalLinkIcon className="t-icon t-icon-small t-icon-muted" />
     },
     {
-      startIcon: <CircleErrorFilledIcon className="t-icon t-icon-danger" />,
-      text: "Pull requests",
+      startIcon: <CircleCheckFilledIcon className="t-icon t-icon-success" />,
+      text: "Pull Requests",
+      onClick: ()=>console.log("hi")
+    }
+  ]
+}
+
+export const SmallBreadcrumbs = Template.bind({});
+SmallBreadcrumbs.args = {
+  size: "sm",
+  data: [
+    { text: "Repos" },
+    {
+      startIcon: <ColoredBox onClick={() => {}} size="6" skin="default"><RepositoryIcon className="t-icon t-icon-small" /></ColoredBox>,
+      text: "mergestat/mergestat",
+      endIcon: <ExternalLinkIcon className="t-icon t-icon-small t-icon-muted" />
+    },
+    {
+      startIcon: <CircleCheckFilledIcon className="t-icon t-icon-success" />,
+      text: "Pull Requests",
       onClick: ()=>console.log("hi")
     }
   ]

--- a/packages/blocks/src/components/BreadcrumbNav/BreadcrumbNav.tsx
+++ b/packages/blocks/src/components/BreadcrumbNav/BreadcrumbNav.tsx
@@ -3,6 +3,7 @@ import { ChevronRightIcon } from '@mergestat/icons';
 import cx from 'classnames';
 
 type BreadcrumbNavProps = {
+  size?: 'default' | 'sm';
   data: {
     text: string;
     startIcon?: React.ReactNode;
@@ -11,9 +12,9 @@ type BreadcrumbNavProps = {
   }[];
 };
 
-export const BreadcrumbNav: React.FC<BreadcrumbNavProps> = ({ data }) => {
+export const BreadcrumbNav: React.FC<BreadcrumbNavProps> = ({ data, size }) => {
   return (
-    <div className="t-breadcrumb-nav">
+    <div className={cx("t-breadcrumb-nav", { ['t-breadcrumb-nav-sm']: size == "sm"})}>
       {data.map((item, index) => {
         return (
           <div

--- a/packages/blocks/styles/components/t-breadcrumb-nav.css
+++ b/packages/blocks/styles/components/t-breadcrumb-nav.css
@@ -9,7 +9,6 @@
          gap-2;
 }
 
-
 .t-breadcrumb-nav-item {
   @apply  flex
           items-center
@@ -26,4 +25,17 @@
 
 .t-breadcrumb-nav-title-active {
   @apply text-gray-900;
+}
+
+.t-breadcrumb-nav-sm .t-breadcrumb-nav-title {
+  @apply text-sm
+         font-medium;
+}
+.t-breadcrumb-nav-sm .t-breadcrumb-nav-item {
+  @apply gap-1.5;
+}
+
+.t-breadcrumb-nav-sm .t-icon {
+  @apply w-4
+         h-4;
 }


### PR DESCRIPTION
- Added `size` prop to `Breadcrumb` component for a smaller breadcrumb variant
<img width="822" alt="image" src="https://user-images.githubusercontent.com/36261498/205288435-bcf95d61-fdf0-4f89-95ca-15f606c1f8cf.png">
