### PR TITLE
Sidebar improvements

### DIFF
--- a/packages/blocks/src/components/organisms/Sidebar/Sidebar.tsx
+++ b/packages/blocks/src/components/organisms/Sidebar/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { ChevronDownIcon, ChevronUpIcon } from '@mergestat/icons';
+import { ChevronDownIcon, ChevronRightIcon } from '@mergestat/icons';
 import cx from 'classnames';
 import React, { createContext, RefAttributes, useCallback, useState } from 'react';
 import logo from '../../../../public/logo-inverse.svg';
@@ -168,7 +168,7 @@ const SidebarItem: React.FC<
                 ..._classname,
                 't-sidebar-item-compact ': compact,
                 't-sidebar-item-sub': level === 'sub',
-                't-sidebar-item-has-children': children,
+                't-sidebar-item-has-children': subNav,
                 disabled: disabled,
                 active: active,
               })}
@@ -177,22 +177,21 @@ const SidebarItem: React.FC<
               onClick={(e) => {
                 e.preventDefault()
                 onClick && onClick()
-                toggleSubNav()
               }}
-            >
-              {icon && <div className='t-sidebar-item-icon-wrap'>{icon}</div>}
-              {(!collapsedContext || level === 'sub') &&
-                <div className='flex-1 truncate max-w-full'>{label}</div>
-              }
+              >
               {subNav && !collapsedContext &&
-                <div
-                  className='t-sidebar-item-icon-wrap'
+                <button
+                  className='t-sidebar-item-toggle'
                   onClick={(e) => {
                     e.preventDefault()
                     toggleSubNav()
                   }}>
-                  {showSubNav ? <ChevronUpIcon className='t-icon t-icon-small' /> : <ChevronDownIcon className='t-icon t-icon-small' />}
-                </div>
+                  {showSubNav ? <ChevronDownIcon className='t-icon t-icon-small' /> : <ChevronRightIcon className='t-icon t-icon-small' />}
+                </button>
+              }
+              {icon && <div className='t-sidebar-item-icon-wrap'>{icon}</div>}
+              {(!collapsedContext || level === 'sub') &&
+                <div className='flex-1 truncate max-w-full'>{label}</div>
               }
             </a>
 
@@ -201,6 +200,7 @@ const SidebarItem: React.FC<
                 {subNav}
               </ul>
             }
+
           </>
         }
       </li>

--- a/packages/blocks/styles/components/t-sidebar.css
+++ b/packages/blocks/styles/components/t-sidebar.css
@@ -23,7 +23,7 @@
 
 /*Sidebar header */
 .t-sidebar-header {
-  @apply px-5
+  @apply px-4
          py-5
          flex
          items-center;
@@ -31,7 +31,7 @@
 
 /*Sidebar footer */
 .t-sidebar-footer {
-  @apply px-5
+  @apply px-4
          h-14
          flex
          mt-4

--- a/packages/blocks/styles/components/t-sidebar.css
+++ b/packages/blocks/styles/components/t-sidebar.css
@@ -23,7 +23,7 @@
 
 /*Sidebar header */
 .t-sidebar-header {
-  @apply px-6
+  @apply px-5
          py-5
          flex
          items-center;
@@ -31,7 +31,7 @@
 
 /*Sidebar footer */
 .t-sidebar-footer {
-  @apply px-6
+  @apply px-5
          h-14
          flex
          mt-4
@@ -45,6 +45,7 @@
 /*Sidebar main */
 .t-sidebar-main {
   @apply flex-grow
+         py-4
          list-none;
 }
 
@@ -59,11 +60,12 @@
 
 /*Sidebar item */
 .t-sidebar-item {
+  padding-left: 48px;
   @apply  flex
           items-center
           py-2
-          px-6
-          space-x-3
+          pr-4
+          space-x-2
           font-medium
           text-gray-500
           focus_outline-none
@@ -75,11 +77,28 @@
           cursor-pointer;
 }
 
+.t-sidebar-item-has-children {
+  @apply pl-4;
+}
+
 .t-sidebar-item-icon-wrap {
   color: inherit;
   @apply flex-shrink-0;
 }
 
+
+.t-sidebar-item-toggle {
+  color: inherit;
+  @apply flex-shrink-0
+          w-6
+          h-6
+          flex
+          items-center
+          justify-center
+          hover_bg-gray-600
+          rounded;
+
+}
 .t-sidebar-item.active {
     @apply text-blue-600
            bg-blue-100;
@@ -102,9 +121,9 @@
 }
 
 .t-sidebar-item-sub {
+  padding-left: 76px;
   @apply text-sm
-         py-2.5
-         pl-14;
+         py-2.5;
 }
 
 .t-sidebar-sub-menu.active {
@@ -167,6 +186,7 @@
 .t-sidebar-collapsed .t-sidebar-footer,
 .t-sidebar-collapsed .t-sidebar-header {
   @apply px-1
+         flex-none
          justify-center;
 }
 


### PR DESCRIPTION
- Removed the `toggleSubNav` function when clicking a sidebar item (only the expand/collapse arrow triggers the sub navigation)
- Increased the size of the toggle and added a hover effect
- Move the toggle to the left to be more in line with similar expand features in Finder, Notion, Gmail (labels), etc

<img width="328" alt="Screenshot 2023-01-17 at 13 48 42" src="https://user-images.githubusercontent.com/36261498/212903815-460af5f3-d13a-4399-91de-00a17c9c9b9f.png">
