### PR TITLE
feat: add UI support for a "close" button on tabs

### DIFF
--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mergestat/blocks",
-  "version": "1.5.30",
+  "version": "1.5.31",
   "description": "Set of UI components for MergeStat project",
   "license": "MIT",
   "repository": {

--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mergestat/blocks",
-  "version": "1.5.29",
+  "version": "1.5.30",
   "description": "Set of UI components for MergeStat project",
   "license": "MIT",
   "repository": {

--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mergestat/blocks",
-  "version": "1.5.28",
+  "version": "1.5.29",
   "description": "Set of UI components for MergeStat project",
   "license": "MIT",
   "repository": {

--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mergestat/blocks",
-  "version": "1.5.26",
+  "version": "1.5.27",
   "description": "Set of UI components for MergeStat project",
   "license": "MIT",
   "repository": {

--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mergestat/blocks",
-  "version": "1.5.31",
+  "version": "1.5.32",
   "description": "Set of UI components for MergeStat project",
   "license": "MIT",
   "repository": {

--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mergestat/blocks",
-  "version": "1.5.27",
+  "version": "1.5.28",
   "description": "Set of UI components for MergeStat project",
   "license": "MIT",
   "repository": {

--- a/packages/blocks/src/components/atoms/Tabs/Tabs.stories.tsx
+++ b/packages/blocks/src/components/atoms/Tabs/Tabs.stories.tsx
@@ -35,22 +35,25 @@ interface TabData {
   title: ReactElement | string
   content: ReactElement | string
   disabled?: boolean
+  closable?: boolean
 }
 
 export const ExampleTabsSecondary: React.FC = () => {
   const [tabs, setTabs] = useState<TabData[]>([
     {
-      title: <><TableIcon className='t-icon' /> <span className='ml-2'>Table</span></>,
+      title: <><TableIcon className='t-icon' /><span className='whitespace-nowrap'>Table</span></>,
       content: <div>Content Table</div>
     },
     {
-      title: <><ChartBarIcon className='t-icon' /> <span className='ml-2'>Bar chart</span></>,
+      title: <><ChartBarIcon className='t-icon' /><span className='whitespace-nowrap'>Bar chart</span></>,
       content: 'Content Bar chart',
-      disabled: true
+      disabled: true,
+      closable: true
     },
     {
-      title: <><TrendUpIcon className='t-icon' /> <span className='ml-2'>Line chart</span></>,
-      content: 'Content Line chart'
+      title: <><TrendUpIcon className='t-icon' /><span className='whitespace-nowrap'>Line chart</span></>,
+      content: 'Content Line chart',
+      closable: true
     }
   ])
 
@@ -58,13 +61,15 @@ export const ExampleTabsSecondary: React.FC = () => {
     switch (tab) {
       case 'line':
         return {
-          title: <><TrendUpIcon className='t-icon' /> <span className='ml-2'>Line chart</span></>,
-          content: 'Content Line chart'
+          title: <><TrendUpIcon className='t-icon' /><span className='whitespace-nowrap'>Line Chart</span></>,
+          content: 'Content Line chart',
+          closable: true
         }
       default:
         return {
-          title: <><DocumentTextIcon className='t-icon' /> <span className='ml-2'>Single metric</span></>,
-          content: 'Content Single metric'
+          title: <><DocumentTextIcon className='t-icon' /><span className='whitespace-nowrap'>Single Metric</span></>,
+          content: 'Content Single metric',
+          closable: true
         }
     }
   }
@@ -78,7 +83,7 @@ export const ExampleTabsSecondary: React.FC = () => {
       <Tabs variant='secondary'>
         <Tabs.List>
           {tabs.map((tab, index) => (
-            <Tabs.Item key={`tab-item-${index}`} disabled={tab.disabled}>{tab.title}</Tabs.Item>
+            <Tabs.Item key={`tab-item-${index}`} disabled={tab.disabled} closable={tab.closable}>{tab.title}</Tabs.Item>
           ))}
 
           <HoverCard
@@ -103,9 +108,9 @@ export const ExampleTabsSecondary: React.FC = () => {
               </Menu>
             )}
           >
-            <div className='flex px-3 py-4 text-blue-600 border-b border-gray-200 hover_bg-gray-100 cursor-pointer'>
+            <div className='t-tab-btn'>
               <PlusIcon className="t-icon" />
-              <span className='px-1'>Add view</span>
+              <span className='whitespace-nowrap'>Add view</span>
               <CaretDownIcon className="t-icon" />
             </div>
           </HoverCard>

--- a/packages/blocks/src/components/atoms/Tabs/Tabs.stories.tsx
+++ b/packages/blocks/src/components/atoms/Tabs/Tabs.stories.tsx
@@ -78,12 +78,23 @@ export const ExampleTabsSecondary: React.FC = () => {
     setTabs([...tabs, getTabData(tab)])
   }
 
+  const removeTab = (tabIndex: number) => {
+    const newTabs = tabs.filter((tab, index) => index !== tabIndex)
+    setTabs(newTabs)
+  }
+
   return (
     <div className="p-2">
       <Tabs variant='secondary'>
         <Tabs.List>
           {tabs.map((tab, index) => (
-            <Tabs.Item key={`tab-item-${index}`} disabled={tab.disabled} closable={tab.closable}>{tab.title}</Tabs.Item>
+            <Tabs.Item key={`tab-item-${index}`}
+              disabled={tab.disabled}
+              closable={tab.closable}
+              onClose={() => removeTab(index)}
+            >
+              {tab.title}
+            </Tabs.Item>
           ))}
 
           <HoverCard

--- a/packages/blocks/src/components/atoms/Tabs/Tabs.stories.tsx
+++ b/packages/blocks/src/components/atoms/Tabs/Tabs.stories.tsx
@@ -39,6 +39,8 @@ interface TabData {
 }
 
 export const ExampleTabsSecondary: React.FC = () => {
+  const [activeTab, setActiveTab] = useState<number>(0)
+
   const [tabs, setTabs] = useState<TabData[]>([
     {
       title: <><TableIcon className='t-icon' /><span className='whitespace-nowrap'>Table</span></>,
@@ -76,16 +78,18 @@ export const ExampleTabsSecondary: React.FC = () => {
 
   const addTab = (tab: string) => {
     setTabs([...tabs, getTabData(tab)])
+    setActiveTab(tabs.length)
   }
 
   const removeTab = (tabIndex: number) => {
     const newTabs = tabs.filter((tab, index) => index !== tabIndex)
     setTabs(newTabs)
+    setActiveTab(0)
   }
 
   return (
     <div className="p-2">
-      <Tabs variant='secondary'>
+      <Tabs variant='secondary' defaultIndex={0} selectedIndex={activeTab} onChange={(index) => setActiveTab(index)}>
         <Tabs.List>
           {tabs.map((tab, index) => (
             <Tabs.Item key={`tab-item-${index}`}

--- a/packages/blocks/src/components/atoms/Tabs/Tabs.stories.tsx
+++ b/packages/blocks/src/components/atoms/Tabs/Tabs.stories.tsx
@@ -119,13 +119,13 @@ export const ExampleTabsSecondary: React.FC = () => {
               </Menu>
             )}
           >
-            <div className='t-tab-btn'>
+            <div className='t-tab-btn border-t border-gray-200'>
               <PlusIcon className="t-icon" />
               <span className='whitespace-nowrap'>Add view</span>
               <CaretDownIcon className="t-icon" />
             </div>
           </HoverCard>
-          <div className='flex-1 border-b border-gray-200'></div>
+          <div className='flex-1 border-y border-gray-200'></div>
         </Tabs.List>
         <Tabs.Panels>
           {tabs.map((tab, index) => (

--- a/packages/blocks/src/components/atoms/Tabs/Tabs.tsx
+++ b/packages/blocks/src/components/atoms/Tabs/Tabs.tsx
@@ -52,7 +52,7 @@ const TabList: React.FC<Record<string, unknown> & React.HTMLAttributes<HTMLEleme
 
   return (
     <RCTab.List
-      className={cx({ 't-tab-line-b': isDefault }, { ..._classname })}
+      className={cx('w-full overflow-x-auto', { 't-tab-line-b': isDefault }, { ..._classname })}
       {...props}
     >
       <nav className={cx('flex', { 'space-x-2': isDefault }, { 't-tab-box-secondary': isSecondary })}>

--- a/packages/blocks/src/components/atoms/Tabs/Tabs.tsx
+++ b/packages/blocks/src/components/atoms/Tabs/Tabs.tsx
@@ -1,6 +1,7 @@
 import { Tab as RCTab } from '@headlessui/react';
 import cx from 'classnames';
-import React from 'react';
+import React, { useState } from 'react';
+import { XIcon } from '@mergestat/icons';
 
 type TabGroupProps = {
   as?: string | React.Component
@@ -13,6 +14,8 @@ type TabGroupProps = {
 
 type TabItemProps = {
   disabled?: boolean
+  closable?: boolean,
+  onClose?: () => void
   variant?: 'secondary' | 'default'
 }
 
@@ -65,9 +68,15 @@ const TabItem: React.FC<TabItemProps & React.HTMLAttributes<HTMLElement>> = ({
   className,
   disabled = false,
   children,
+  closable,
+  onClose,
   variant,
   ...props
 }) => {
+  const [visible, setVisible] = useState<boolean>(true);
+
+  if (!visible) return null;
+
   const variantStyle = variant === 'secondary' ? 't-tab-secondary' : 't-tab'
   return (
     <RCTab
@@ -81,6 +90,16 @@ const TabItem: React.FC<TabItemProps & React.HTMLAttributes<HTMLElement>> = ({
       }
     >
       {children}
+      {closable &&
+        <div
+          className='t-tab-close-btn'
+          onClick={() => {
+            setVisible(false);
+            if (onClose) onClose();
+          }}>
+          <XIcon className='t-icon t-icon-small' />
+        </div>
+      }
     </RCTab>
   );
 }

--- a/packages/blocks/src/components/atoms/Tabs/Tabs.tsx
+++ b/packages/blocks/src/components/atoms/Tabs/Tabs.tsx
@@ -6,10 +6,12 @@ import React from 'react';
 type TabGroupProps = {
   as?: string | React.Component
   defaultIndex?: number
+  selectedIndex?: number
   onChange?: (index: number) => void
   vertical?: boolean
   manual?: boolean
   variant?: 'secondary' | 'default'
+  children?: React.ReactNode
 }
 
 type TabItemProps = {
@@ -19,16 +21,11 @@ type TabItemProps = {
   variant?: 'secondary' | 'default'
 }
 
-const TabGroup: React.FC<
-  TabGroupProps &
-  React.DetailedHTMLProps<
-    React.HTMLAttributes<HTMLBaseElement>,
-    HTMLBaseElement
-  >
-> = ({ children, defaultIndex, onChange, vertical, variant = 'default' }) => {
+const TabGroup: React.FC<TabGroupProps> = ({ children, defaultIndex, selectedIndex, onChange, vertical, variant = 'default' }) => {
   return (
     <RCTab.Group
       defaultIndex={defaultIndex}
+      selectedIndex={selectedIndex}
       onChange={onChange}
       vertical={vertical}
       manual
@@ -124,14 +121,7 @@ const TabPanel: React.FC<Record<string, unknown> & React.HTMLAttributes<HTMLElem
   )
 }
 
-interface CompoundedComponent
-  extends React.ForwardRefExoticComponent<
-    TabGroupProps &
-    React.DetailedHTMLProps<
-      React.HTMLAttributes<HTMLBaseElement>,
-      HTMLBaseElement
-    >
-  > {
+interface CompoundedComponent extends React.ForwardRefExoticComponent<TabGroupProps> {
   Group: typeof TabGroup;
   List: typeof TabList;
   Item: typeof TabItem;

--- a/packages/blocks/src/components/atoms/Tabs/Tabs.tsx
+++ b/packages/blocks/src/components/atoms/Tabs/Tabs.tsx
@@ -1,7 +1,7 @@
 import { Tab as RCTab } from '@headlessui/react';
-import cx from 'classnames';
-import React, { useState } from 'react';
 import { XIcon } from '@mergestat/icons';
+import cx from 'classnames';
+import React from 'react';
 
 type TabGroupProps = {
   as?: string | React.Component
@@ -37,7 +37,7 @@ const TabGroup: React.FC<
         return React.cloneElement(child as React.ReactElement, { variant })
       })}
     </RCTab.Group>
-  );
+  )
 }
 
 const TabList: React.FC<Record<string, unknown> & React.HTMLAttributes<HTMLElement>> = ({
@@ -61,7 +61,7 @@ const TabList: React.FC<Record<string, unknown> & React.HTMLAttributes<HTMLEleme
         })}
       </nav>
     </RCTab.List>
-  );
+  )
 }
 
 const TabItem: React.FC<TabItemProps & React.HTMLAttributes<HTMLElement>> = ({
@@ -73,10 +73,6 @@ const TabItem: React.FC<TabItemProps & React.HTMLAttributes<HTMLElement>> = ({
   variant,
   ...props
 }) => {
-  const [visible, setVisible] = useState<boolean>(true);
-
-  if (!visible) return null;
-
   const variantStyle = variant === 'secondary' ? 't-tab-secondary' : 't-tab'
   return (
     <RCTab
@@ -94,14 +90,13 @@ const TabItem: React.FC<TabItemProps & React.HTMLAttributes<HTMLElement>> = ({
         <div
           className='t-tab-close-btn'
           onClick={() => {
-            setVisible(false);
-            if (onClose) onClose();
+            onClose && onClose()
           }}>
           <XIcon className='t-icon t-icon-small' />
         </div>
       }
     </RCTab>
-  );
+  )
 }
 
 const TabPanels: React.FC<Record<string, unknown> & React.HTMLAttributes<HTMLElement>> =
@@ -112,7 +107,7 @@ const TabPanels: React.FC<Record<string, unknown> & React.HTMLAttributes<HTMLEle
       <RCTab.Panels {...props} className={cx({ ..._classname })}>
         {children}
       </RCTab.Panels>
-    );
+    )
   }
 
 const TabPanel: React.FC<Record<string, unknown> & React.HTMLAttributes<HTMLElement>> = ({
@@ -126,7 +121,7 @@ const TabPanel: React.FC<Record<string, unknown> & React.HTMLAttributes<HTMLElem
     <RCTab.Panel {...props} className={cx({ ..._classname })}>
       {children}
     </RCTab.Panel>
-  );
+  )
 }
 
 interface CompoundedComponent

--- a/packages/blocks/styles/components/t-table.css
+++ b/packages/blocks/styles/components/t-table.css
@@ -16,7 +16,6 @@
 
 .t-table-sticky-header thead tr {
   @apply sticky
-         z-10
          top-0;
 }
 

--- a/packages/blocks/styles/components/t-tabs.css
+++ b/packages/blocks/styles/components/t-tabs.css
@@ -26,8 +26,6 @@
 .t-tab-line-b {
     @apply border-b
            border-gray-200
-           w-full 
-           overflow-x-auto
 }
 
 .t-tab-secondary {

--- a/packages/blocks/styles/components/t-tabs.css
+++ b/packages/blocks/styles/components/t-tabs.css
@@ -26,6 +26,8 @@
 .t-tab-line-b {
     @apply border-b
            border-gray-200
+           w-full 
+           overflow-x-auto
 }
 
 .t-tab-secondary {
@@ -40,14 +42,14 @@
            h-full
            bg-gray-100
            hover_bg-gray-200
-           border-b
+           border-y
            border-r
+           border-gray-200
+           whitespace-nowrap
 }
 
 .t-tab-box-secondary {
-    @apply border-t
-           h-12
-           border-gray-200
+    @apply h-12
 }
 
 .t-tab-btn {

--- a/packages/blocks/styles/components/t-tabs.css
+++ b/packages/blocks/styles/components/t-tabs.css
@@ -10,12 +10,14 @@
 }
 
 .t-tab {
-    padding-top: 0.9375rem;
-    padding-bottom: 0.9375rem;
+    padding-top: .9375rem;
+    padding-bottom: .9375rem;
     @apply px-1
            flex
            items-center
            border-b-2
+           leading-6
+           space-x-2
            border-transparent
            font-medium
            -mb-px;
@@ -27,13 +29,15 @@
 }
 
 .t-tab-secondary {
-    padding-top: 0.9375rem;
-    padding-bottom: 0.9375rem;
     @apply px-3
+           py-3
            flex
            text-gray-500
            font-medium
            items-center
+           leading-6
+           space-x-2
+           h-full
            bg-gray-100
            hover_bg-gray-200
            border-b
@@ -42,7 +46,23 @@
 
 .t-tab-box-secondary {
     @apply border-t
+           h-12
            border-gray-200
+}
+
+.t-tab-btn {
+  @apply flex
+         px-3
+         py-3
+         h-full
+         items-center
+         space-x-2
+         leading-6
+         text-blue-600
+         border-b
+         border-gray-200
+         hover_bg-gray-100
+         cursor-pointer;
 }
 
 .t-tab[disabled] {
@@ -87,3 +107,15 @@
            hover_border-gray-300;
 }
 /* purgecss end ignore */
+
+.t-tab-close-btn {
+  @apply ml-2
+       hover_bg-gray-150
+         mix-blend-multiply
+         flex
+         items-center
+         justify-center
+         h-6
+         w-6
+         rounded;
+}

--- a/packages/blocks/styles/components/t-tabs.css
+++ b/packages/blocks/styles/components/t-tabs.css
@@ -42,7 +42,8 @@
            h-full
            bg-gray-100
            hover_bg-gray-200
-           border-y
+           border-t
+           border-b
            border-r
            border-gray-200
            whitespace-nowrap

--- a/packages/blocks/styles/components/t-tabs.css
+++ b/packages/blocks/styles/components/t-tabs.css
@@ -110,7 +110,7 @@
 
 .t-tab-close-btn {
   @apply ml-2
-       hover_bg-gray-150
+         hover_bg-gray-150
          mix-blend-multiply
          flex
          items-center


### PR DESCRIPTION
<img width="983" alt="image" src="https://user-images.githubusercontent.com/36261498/213177244-fd910fe5-bf99-4fd6-b8f6-8a036bcf2f9b.png">

- Added `Closable` prop for `Tab` items
- Currently it only removes the tab, but doesn't switch the tab content yet, how do you recommend doing this @german-mergestat?

Resolves #85