### PR TITLE
fix: remove active state from small breadcrumbs

### DIFF
--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mergestat/blocks",
-  "version": "1.5.32",
+  "version": "1.5.33",
   "description": "Set of UI components for MergeStat project",
   "license": "MIT",
   "repository": {

--- a/packages/blocks/src/components/atoms/BreadcrumbNav/BreadcrumbNav.tsx
+++ b/packages/blocks/src/components/atoms/BreadcrumbNav/BreadcrumbNav.tsx
@@ -24,7 +24,7 @@ export const BreadcrumbNav: React.FC<BreadcrumbNavProps> = ({ data, size }) => {
             {index !== 0 && <ChevronRightIcon className="t-icon t-icon-muted cursor-default" />}
             {item.startIcon && item.startIcon}
             <div
-              className={cx('t-breadcrumb-nav-title', index === data.length - 1 && 't-breadcrumb-nav-title-active')}
+              className={cx('t-breadcrumb-nav-title', index === data.length - 1 && size !== 'sm' && 't-breadcrumb-nav-title-active')}
               onClick={() => item.onClick && item.onClick()}
             >
               {item.text}


### PR DESCRIPTION
<img width="1056" alt="image" src="https://user-images.githubusercontent.com/36261498/213503974-222bbf20-4413-484f-9656-85932fd85e6e.png">
