### PR TITLE
chore(editable-text): Adjusting Editable Text component

### DIFF
--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mergestat/blocks",
-  "version": "1.5.42",
+  "version": "1.5.43",
   "description": "Set of UI components for MergeStat project",
   "license": "MIT",
   "repository": {

--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mergestat/blocks",
-  "version": "1.5.41",
+  "version": "1.5.42",
   "description": "Set of UI components for MergeStat project",
   "license": "MIT",
   "repository": {

--- a/packages/blocks/src/components/molecules/EditableText/EditableText.tsx
+++ b/packages/blocks/src/components/molecules/EditableText/EditableText.tsx
@@ -3,18 +3,17 @@ import React from 'react';
 import { ColoredBox } from '../../atoms/ColoredBox';
 import { Input } from '../../atoms/Form';
 
-interface InputEditableText extends React.DetailedHTMLProps<
-  React.InputHTMLAttributes<HTMLInputElement>,
-  HTMLInputElement
-> {
-  error?: boolean
-}
-
 export type EditableTextProps = {
   className?: string
   icon?: React.ReactElement
-  title: InputEditableText
-  desc: InputEditableText
+  title: React.DetailedHTMLProps<
+    React.InputHTMLAttributes<HTMLInputElement>,
+    HTMLInputElement
+  >
+  desc: React.DetailedHTMLProps<
+    React.InputHTMLAttributes<HTMLInputElement>,
+    HTMLInputElement
+  >
 }
 
 export const EditableText: React.FC<EditableTextProps> = ({ className, icon, title, desc }) => {
@@ -34,7 +33,7 @@ export const EditableText: React.FC<EditableTextProps> = ({ className, icon, tit
             })}>
             {title?.value}
           </h4>
-          : <Input variant={title.error ? 'ghost-error' : 'ghost'}
+          : <Input variant={title.required ? 'ghost-error' : 'ghost'}
             className={cx('t-input-title leading-none')}
             {...title}
           />}
@@ -47,7 +46,7 @@ export const EditableText: React.FC<EditableTextProps> = ({ className, icon, tit
             })}>
             {desc?.value}
           </p>
-          : <Input variant={desc.error ? 'ghost-error' : 'ghost'}
+          : <Input variant={desc.required ? 'ghost-error' : 'ghost'}
             className={cx('t-input-desc leading-none')}
             {...desc}
           />}

--- a/packages/blocks/src/components/molecules/EditableText/EditableText.tsx
+++ b/packages/blocks/src/components/molecules/EditableText/EditableText.tsx
@@ -26,22 +26,31 @@ export const EditableText: React.FC<EditableTextProps> = ({ className, icon, tit
         {icon}
       </ColoredBox>}
       <div className='ml-2 flex-grow'>
-        <Input variant={title.error ? 'ghost-error' : 'ghost'}
-          className={cx(
-            't-input-title leading-none', {
-            't-input-readonly': title.readOnly,
-            't-input-onclick': !!title.onClick
-          })}
-          {...title}
-        />
-        <Input variant={desc.error ? 'ghost-error' : 'ghost'}
-          className={cx(
-            't-input-desc leading-none', {
-            't-input-readonly': desc.readOnly,
-            't-input-onclick': !!desc.onClick
-          })}
-          {...desc}
-        />
+        {title.readOnly ?
+          <h4 onClick={title.onClick}
+            className={cx(
+              't-h4 px-3 mb-0 bg-transparent', {
+              't-input-onclick': !!title.onClick
+            })}>
+            {title?.value}
+          </h4>
+          : <Input variant={title.error ? 'ghost-error' : 'ghost'}
+            className={cx('t-input-title leading-none')}
+            {...title}
+          />}
+
+        {desc.readOnly ?
+          <p onClick={desc.onClick}
+            className={cx(
+              't-h4 px-3 mb-0 bg-transparent t-input-desc', {
+              't-input-onclick': !!desc.onClick
+            })}>
+            {desc?.value}
+          </p>
+          : <Input variant={desc.error ? 'ghost-error' : 'ghost'}
+            className={cx('t-input-desc leading-none')}
+            {...desc}
+          />}
       </div>
     </div>
   )

--- a/packages/blocks/styles/components/t-input.css
+++ b/packages/blocks/styles/components/t-input.css
@@ -81,14 +81,9 @@
 }
 
 .t-input-desc {
-  @apply text-sm
+  @apply font-normal
+         text-sm
          text-gray-500
-}
-
-.t-input-readonly {
-  @apply hover_bg-transparent
-         focus_bg-transparent
-         focus_border-transparent
 }
 
 .t-input-onclick {


### PR DESCRIPTION
Adjusting Editable Text component for not using `input` when it is read-only.