### PR TITLE
UI improvements

### DIFF
--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mergestat/blocks",
-  "version": "1.5.47",
+  "version": "1.5.48",
   "description": "Set of UI components for MergeStat project",
   "license": "MIT",
   "repository": {

--- a/packages/blocks/src/components/atoms/RadioCard/RadioCard.tsx
+++ b/packages/blocks/src/components/atoms/RadioCard/RadioCard.tsx
@@ -21,7 +21,7 @@ export const RadioCard: React.FC<RadioCardProps> = ({
   return (
     <div
       className={cx('t-radio-card', {
-        't-tag-blue': isSelected,
+        't-radio-card-selected': isSelected,
         ..._classname
       })}
       onClick={() => {

--- a/packages/blocks/styles/components/t-avatar.css
+++ b/packages/blocks/styles/components/t-avatar.css
@@ -11,7 +11,8 @@
            rounded-full
            font-medium
            overflow-hidden
-           bg-gray-200
+           bg-gray-100
+           mix-blend-multiply
            text-gray-500;
 }
 
@@ -54,8 +55,8 @@
 }
 
 .t-avatar-xl .t-icon {
-    @apply w-8
-           h-8;
+    @apply w-6
+           h-6;
 }
 
 .t-avatar-2xl {
@@ -89,7 +90,7 @@
 }
 
 .t-avatar-dark {
-    @apply bg-gray-700
+    @apply bg-gray-500
             text-white;
 }
 

--- a/packages/blocks/styles/components/t-button-toolbar.css
+++ b/packages/blocks/styles/components/t-button-toolbar.css
@@ -6,9 +6,7 @@
 
 .t-button-toolbar {
     @apply flex
-           items-center;
+           items-center
+           space-x-2;
 }
 
-.t-button-toolbar .t-button + .t-button {
-    @apply ml-2;
-}

--- a/packages/blocks/styles/components/t-button.css
+++ b/packages/blocks/styles/components/t-button.css
@@ -128,7 +128,7 @@
 }
 
 .t-button-borderless-muted {
-  @apply text-gray-600;
+  @apply text-gray-500;
 }
 
 .t-button-danger-primary {

--- a/packages/blocks/styles/components/t-label.css
+++ b/packages/blocks/styles/components/t-label.css
@@ -5,7 +5,7 @@
 .t-label {
   @apply block
          font-medium
-         text-gray-800
+         text-gray-600
          py-1.5
          leading-6;
 }

--- a/packages/blocks/styles/components/t-modal.css
+++ b/packages/blocks/styles/components/t-modal.css
@@ -47,7 +47,7 @@
           shadow-xl
           transform
           transition-all
-          sm_align-middle
+          align-middle
           sm_max-w-2xl
           w-full;
 }

--- a/packages/blocks/styles/components/t-radio-card.css
+++ b/packages/blocks/styles/components/t-radio-card.css
@@ -19,7 +19,7 @@
          text-gray-600;
 }
 
-.t-radio-card.t-tag-blue {
+.t-radio-card.t-radio-card-selected {
   @apply bg-blue-100
          text-blue-600
          ring-1

--- a/packages/blocks/styles/components/t-sidebar.css
+++ b/packages/blocks/styles/components/t-sidebar.css
@@ -62,7 +62,7 @@
 .t-sidebar-item {
   @apply  flex
           items-center
-          py-2
+          py-2.5
           px-5
           space-x-3
           font-medium

--- a/packages/blocks/styles/components/t-table.css
+++ b/packages/blocks/styles/components/t-table.css
@@ -15,8 +15,10 @@
 }
 
 .t-table-sticky-header thead tr {
+  z-index: 1;
   @apply sticky
-         top-0;
+         top-0
+         bg-gray-50;
 }
 
 .t-table-sticky-header thead tr th:before {

--- a/packages/blocks/styles/components/t-table.css
+++ b/packages/blocks/styles/components/t-table.css
@@ -62,10 +62,11 @@
 .t-table-default th {
   @apply py-3
          text-left
+         text-sm
          border-b-2
          font-semibold
          bg-gray-50
-         text-gray-700;
+         text-gray-600;
 }
 
 /* Alignment for button toolbars */
@@ -239,7 +240,7 @@ table th.down .sortable__th__arrow {
 /* Dense tables */
 .t-table-dense th,
 .t-table-dense td {
-  @apply py-2.5
+  @apply py-2
          text-sm;
 }
 

--- a/packages/blocks/styles/components/t-table.css
+++ b/packages/blocks/styles/components/t-table.css
@@ -62,7 +62,6 @@
 .t-table-default th {
   @apply py-3
          text-left
-         text-sm
          border-b-2
          font-semibold
          bg-gray-50

--- a/packages/blocks/styles/components/t-tabs.css
+++ b/packages/blocks/styles/components/t-tabs.css
@@ -19,8 +19,7 @@
            leading-6
            space-x-2
            border-transparent
-           font-medium
-           -mb-px;
+           font-medium;
 }
 
 .t-tab-line-b {
@@ -60,6 +59,7 @@
          space-x-2
          leading-6
          text-blue-600
+         font-medium
          border-b
          border-gray-200
          hover_bg-gray-100
@@ -82,6 +82,10 @@
            opacity-80
            border-gray-200
            pointer-events-none;
+}
+
+.t-tab-secondary:first-child {
+  @apply pl-8;
 }
 
 /* purgecss start ignore */
@@ -108,7 +112,6 @@
            hover_border-gray-300;
 }
 /* purgecss end ignore */
-
 .t-tab-close-btn {
   @apply ml-2
          hover_bg-gray-150

--- a/packages/blocks/styles/components/t-tabs.css
+++ b/packages/blocks/styles/components/t-tabs.css
@@ -35,7 +35,8 @@
            font-medium
            items-center
            leading-6
-           space-x-2
+           space-x-1.5
+           text-sm
            h-full
            bg-gray-100
            hover_bg-gray-200
@@ -44,6 +45,12 @@
            border-r
            border-gray-200
            whitespace-nowrap
+}
+
+.t-tab-secondary .t-icon,
+.t-tab-btn .t-icon {
+  @apply h-4
+         w-4;
 }
 
 .t-tab-box-secondary {
@@ -56,7 +63,8 @@
          py-3
          h-full
          items-center
-         space-x-2
+         space-x-1.5
+         text-sm
          leading-6
          text-blue-600
          font-medium

--- a/packages/blocks/styles/components/t-toolbar.css
+++ b/packages/blocks/styles/components/t-toolbar.css
@@ -15,10 +15,11 @@
 .t-toolbar-right {
     @apply flex-auto;
 }
+
 .t-toolbar-left {
     @apply flex
            flex-row
-           space-x-2
+           space-x-4
            justify-start
            items-center;
 }
@@ -26,7 +27,7 @@
 .t-toolbar-right {
     @apply flex
            flex-row
-           space-x-2
+           space-x-4
            justify-end
            items-center;
 }

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mergestat/icons",
-  "version": "1.2.13",
+  "version": "1.2.14",
   "description": "Set of Icon for MergeStat project",
   "license": "MIT",
   "repository": {

--- a/packages/icons/src/icons/ClockHistory.tsx
+++ b/packages/icons/src/icons/ClockHistory.tsx
@@ -3,7 +3,7 @@ import { IconProps } from '../utils/types';
 
 function SvgClock(props: IconProps) {
   return (
-    <Icon width="18" height="18" viewBox="0 0 18 18" {...props}>
+    <Icon {...props}>
       <path
         fillRule="evenodd"
         clipRule="evenodd"


### PR DESCRIPTION
- Fix `clockHistory` icon size
- Move changes from `global.css` in the mergestat back to `blocks` (has been used in the past as a quick way to fix some things in `mergestat`) so we can clean up the file there
- Update `Label` color
- Updated spacing sidebar items
- Update muted borderless buttons color
- Update table header styles
- Added padding-left on the first secondary tab item so it can align with the other items in a view