### PR TITLE
fix: when a parent item is clicked, always expand the subnav by default

### DIFF
--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mergestat/blocks",
-  "version": "1.5.51",
+  "version": "1.5.52",
   "description": "Set of UI components for MergeStat project",
   "license": "MIT",
   "repository": {

--- a/packages/blocks/src/components/organisms/Sidebar/Sidebar.tsx
+++ b/packages/blocks/src/components/organisms/Sidebar/Sidebar.tsx
@@ -170,6 +170,7 @@ const SidebarItem: React.FC<
               })}
               onClick={(e) => {
                 e.preventDefault()
+                setShowSubNav(true)
                 onClick && onClick()
               }}
             >


### PR DESCRIPTION
Makes the interaction feel more natural. If you click on a "parent" nav item, it automatically expands to show the sub nav items