### PR TITLE
feat: add `defaultOpen` prop to `SidebarItem` component

### DIFF
--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mergestat/blocks",
-  "version": "1.5.55",
+  "version": "1.5.56",
   "description": "Set of UI components for MergeStat project",
   "license": "MIT",
   "repository": {

--- a/packages/blocks/src/components/organisms/Sidebar/Sidebar.stories.tsx
+++ b/packages/blocks/src/components/organisms/Sidebar/Sidebar.stories.tsx
@@ -69,6 +69,7 @@ export const ExampleDarkSideBar: React.FC = () => {
         <Sidebar.Item
           compact={false}
           label='Settings'
+          defaultOpen
           icon={<CogIcon className='t-icon' />}
           subNav={
             <>

--- a/packages/blocks/src/components/organisms/Sidebar/Sidebar.tsx
+++ b/packages/blocks/src/components/organisms/Sidebar/Sidebar.tsx
@@ -18,6 +18,7 @@ type SidebarItemProps = {
   subNav?: React.ReactNode
   collapsed?: boolean
   level?: 'sub' | 'default'
+  defaultOpen?: boolean
   onClick?: () => void
 }
 
@@ -117,7 +118,7 @@ const SidebarItem: React.FC<
   level,
   ...props
 }) => {
-    const [showSubNav, setShowSubNav] = useState(false);
+    const [showSubNav, setShowSubNav] = useState(props.defaultOpen || false);
     const collapsedContext = React.useContext(SidebarContext)
 
     const _classname = className ? { [className]: !!className } : {}


### PR DESCRIPTION
The purpose of this is to allow a user/consumer of the sidebar to set a default open state for navbar items. For example, on page load, if a submenu should start open.