### PR TITLE
chore: continue using the `defaultOpen` name

### DIFF
--- a/packages/blocks/src/components/organisms/Sidebar/Sidebar.stories.tsx
+++ b/packages/blocks/src/components/organisms/Sidebar/Sidebar.stories.tsx
@@ -69,7 +69,7 @@ export const ExampleDarkSideBar: React.FC = () => {
         <Sidebar.Item
           compact={false}
           label='Settings'
-          open
+          defaultOpen
           icon={<CogIcon className='t-icon' />}
           subNav={
             <>

--- a/packages/blocks/src/components/organisms/Sidebar/Sidebar.tsx
+++ b/packages/blocks/src/components/organisms/Sidebar/Sidebar.tsx
@@ -18,7 +18,7 @@ type SidebarItemProps = {
   subNav?: React.ReactNode
   collapsed?: boolean
   level?: 'sub' | 'default'
-  open?: boolean
+  defaultOpen?: boolean
   onClick?: () => void
 }
 
@@ -116,9 +116,10 @@ const SidebarItem: React.FC<
   compact = true,
   subNav,
   level,
+  defaultOpen,
   ...props
 }) => {
-    const [showSubNav, setShowSubNav] = useState(props.open || false);
+    const [showSubNav, setShowSubNav] = useState(defaultOpen || false);
     const collapsedContext = React.useContext(SidebarContext)
 
     const _classname = className ? { [className]: !!className } : {}


### PR DESCRIPTION
but address the underlying console error